### PR TITLE
Example of wrtcStar for signalling server usage with upgrader not working

### DIFF
--- a/examples/custom-libp2p/index.js
+++ b/examples/custom-libp2p/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const PeerInfo = require('peer-info');
 const Libp2p = require('libp2p')
 const IPFS = require('ipfs')
 const TCP = require('libp2p-tcp')
@@ -9,6 +10,21 @@ const SPDY = require('libp2p-spdy')
 const KadDHT = require('libp2p-kad-dht')
 const MPLEX = require('libp2p-mplex')
 const SECIO = require('libp2p-secio')
+
+const Websockets = require('libp2p-websockets')
+const WebrtcStar = require('libp2p-webrtc-star')
+const wrtc = require('wrtc')
+
+const Upgrader = require('./node_modules/libp2p/src/upgrader')
+
+const signalServerIP = () => {
+  return '127.0.0.1'
+}
+
+const signalServerCID = () => {
+  return 'QmXEWB3eEUZygXPbxhs4XuyJvffJUXSVe8PmdNrN123456'
+}
+
 
 /**
  * Options for the libp2p bundle
@@ -25,113 +41,109 @@ const SECIO = require('libp2p-secio')
  * @param {libp2pBundle~options} opts The options to use when generating the libp2p node
  * @returns {Libp2p} Our new libp2p node
  */
-const libp2pBundle = (opts) => {
+const libp2pBundle = () => {
   // Set convenience variables to clearly showcase some of the useful things that are available
-  const peerInfo = opts.peerInfo
-  const peerBook = opts.peerBook
-  const bootstrapList = opts.config.Bootstrap
+  PeerInfo.create().then((pi) => {
+    const peerInfo = pi
+    // const peerBook = null // opts.peerBook
+    const bootstrapList = [`/ip4/${signalServerIP()}/tcp/63785/ipfs/${signalServerCID()}`]
 
-  // Build and return our libp2p node
-  // n.b. for full configuration options, see https://github.com/libp2p/js-libp2p/blob/master/doc/CONFIGURATION.md
-  return new Libp2p({
-    peerInfo,
-    peerBook,
-    // Lets limit the connection managers peers and have it check peer health less frequently
-    connectionManager: {
-      minPeers: 25,
-      maxPeers: 100,
-      pollInterval: 5000
-    },
-    modules: {
-      transport: [
-        TCP
-      ],
-      streamMuxer: [
-        MPLEX,
-        SPDY
-      ],
-      connEncryption: [
-        SECIO
-      ],
-      peerDiscovery: [
-        MulticastDNS,
-        Bootstrap
-      ],
-      dht: KadDHT
-    },
-    config: {
-      peerDiscovery: {
-        autoDial: true, // auto dial to peers we find when we have less peers than `connectionManager.minPeers`
-        mdns: {
-          interval: 10000,
-          enabled: true
+    const upgrader = new Upgrader({ localPeer: peerInfo })
+    const wrtcStar = new WebrtcStar({ wrtc, upgrader })
+    // Build and return our libp2p node
+    // n.b. for full configuration options, see https://github.com/libp2p/js-libp2p/blob/master/doc/CONFIGURATION.md
+    const p2p = new Libp2p({
+      peerInfo,
+      // Lets limit the connection managers peers and have it check peer health less frequently
+      connectionManager: {
+        minPeers: 25,
+        maxPeers: 100,
+        pollInterval: 5000
+      },
+      modules: {
+        transport: [
+          TCP,
+          Websockets,
+          wrtcStar
+        ],
+        streamMuxer: [
+          MPLEX,
+          SPDY
+        ],
+        connEncryption: [
+          SECIO
+        ],
+        peerDiscovery: [
+          MulticastDNS,
+          Bootstrap,
+          wrtcStar.discovery
+        ],
+        dht: KadDHT
+      },
+      config: {
+        EXPERIMENTAL: {
+          pubsub: true
         },
-        bootstrap: {
-          interval: 30e3,
+        peerDiscovery: {
+          autoDial: true, // auto dial to peers we find when we have less peers than `connectionManager.minPeers`
+          mdns: {
+            interval: 10000,
+            enabled: true
+          },
+          bootstrap: {
+            interval: 30e3,
+            enabled: true,
+            list: bootstrapList
+          }
+        },
+        // Turn on relay with hop active so we can connect to more peers
+        relay: {
           enabled: true,
-          list: bootstrapList
+          hop: {
+            enabled: true,
+            active: true
+          }
+        },
+        dht: {
+          enabled: true,
+          kBucketSize: 20,
+          randomWalk: {
+            enabled: true,
+            interval: 10e3, // This is set low intentionally, so more peers are discovered quickly. Higher intervals are recommended
+            timeout: 2e3 // End the query quickly since we're running so frequently
+          }
+        },
+        pubsub: {
+          enabled: true
         }
       },
-      // Turn on relay with hop active so we can connect to more peers
-      relay: {
+      metrics: {
         enabled: true,
-        hop: {
-          enabled: true,
-          active: true
-        }
-      },
-      dht: {
-        enabled: true,
-        kBucketSize: 20,
-        randomWalk: {
-          enabled: true,
-          interval: 10e3, // This is set low intentionally, so more peers are discovered quickly. Higher intervals are recommended
-          timeout: 2e3 // End the query quickly since we're running so frequently
-        }
-      },
-      pubsub: {
-        enabled: true
+        computeThrottleMaxQueueSize: 1000,  // How many messages a stat will queue before processing
+        computeThrottleTimeout: 2000,       // Time in milliseconds a stat will wait, after the last item was added, before processing
+        movingAverageIntervals: [           // The moving averages that will be computed
+          60 * 1000, // 1 minute
+          5 * 60 * 1000, // 5 minutes
+          15 * 60 * 1000 // 15 minutes
+        ],
+        maxOldPeersRetention: 50            // How many disconnected peers we will retain stats for
       }
-    },
-    metrics: {
-      enabled: true,
-      computeThrottleMaxQueueSize: 1000,  // How many messages a stat will queue before processing
-      computeThrottleTimeout: 2000,       // Time in milliseconds a stat will wait, after the last item was added, before processing
-      movingAverageIntervals: [           // The moving averages that will be computed
-        60 * 1000, // 1 minute
-        5 * 60 * 1000, // 5 minutes
-        15 * 60 * 1000 // 15 minutes
-      ],
-      maxOldPeersRetention: 50            // How many disconnected peers we will retain stats for
-    }
-  })
+    })
+
+    p2p.start().then(() => {
+      console.log('p2p started...');
+      p2p.on('peer:connect', (peerInfo) => {
+        console.info(`Connected to ${peerInfo.id.toB58String()}!`)
+      })
+    }).catch((ex) => {
+      console.error(ex);
+      console.error(ex.stack);
+    })
+
+  }).catch((ex) => {
+    console.error(ex);
+  });
+
 }
 
-async function main () {
-  // Now that we have our custom libp2p bundle, let's start up the ipfs node!
-  const node = await IPFS.create({
-    libp2p: libp2pBundle
-  })
-
-  // Lets log out the number of peers we have every 2 seconds
-  setInterval(async () => {
-    try {
-      const peers = await node.swarm.peers()
-      console.log(`The node now has ${peers.length} peers.`)
-    } catch (err) {
-      console.log('An error occurred trying to check our peers:', err)
-    }
-  }, 2000)
-
-  // Log out the bandwidth stats every 4 seconds so we can see how our configuration is doing
-  setInterval(async () => {
-    try {
-      const stats = await node.stats.bw()
-      console.log(`\nBandwidth Stats: ${JSON.stringify(stats, null, 2)}\n`)
-    } catch (err) {
-      console.log('An error occurred trying to check our stats:', err)
-    }
-  }, 4000)
-}
-
-main()
+libp2pBundle()

--- a/examples/custom-libp2p/index.js
+++ b/examples/custom-libp2p/index.js
@@ -18,7 +18,7 @@ const wrtc = require('wrtc')
 const Upgrader = require('./node_modules/libp2p/src/upgrader')
 
 const signalServerIP = () => {
-  return '127.0.0.1'
+  return '127.0.0.1' // (I am running an instance of libp2p-webrtc-star/src/sig-server on a droplet)
 }
 
 const signalServerCID = () => {

--- a/examples/custom-libp2p/package.json
+++ b/examples/custom-libp2p/package.json
@@ -17,7 +17,8 @@
     "libp2p-mplex": "^0.9.3",
     "libp2p-secio": "^0.12.2",
     "libp2p-spdy": "^0.13.3",
-    "libp2p-tcp": "^0.14.5"
+    "libp2p-tcp": "^0.14.5",
+    "wrtc": "*"
   },
   "devDependencies": {
     "execa": "^4.0.0",


### PR DESCRIPTION
This is an example patch to the js-ipfs example for a custom libp2p node where the use of wrtc for peer discovery crashes with an error trying to set the modules up for wrtc. 

I have all rigged up using the Upgrader object by importing it directly...

(_Very_ hackish, I know, but there seems to be no good example of using the Upgrader in the wild other than mocks in ipfs repos)

The error I get is here:
```
TypeError: Cannot read property 'Symbol(Symbol.toStringTag)' of undefined
    at /home/ddahl/projects/forks/js-ipfs/examples/custom-libp2p/node_modules/libp2p/src/index.js:118:38
    at Array.forEach (<anonymous>)
    at new Libp2p (/home/ddahl/projects/forks/js-ipfs/examples/custom-libp2p/node_modules/libp2p/src/index.js:117:29)
    at /home/ddahl/projects/forks/js-ipfs/examples/custom-libp2p/index.js:55:17
    at processTicksAndRejections (internal/process/task_queues.js:89:5)
```
It seems as though the wrtc (or a property of it) instance is `undefined`.

If you comment out the `wrtcStar` transport module, this will run. 